### PR TITLE
塔羅日記功能

### DIFF
--- a/app/Http/Controllers/TarotDiaryController.php
+++ b/app/Http/Controllers/TarotDiaryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\TarotDiaryRequest;
+use App\Http\Requests\UpdateTarotDiaryRequest;
 use App\Services\TarotDiaryService;
 use App\Traits\ApiResponse;
 use Carbon\Carbon;
@@ -21,27 +22,11 @@ class TarotDiaryController extends Controller
     }
 
     /**
-     * 取得登入使用者 ID，如未登入則回傳錯誤
-     */
-    private function getUserIdOrAbort()
-    {
-        $userId = Auth::id();
-        if (! $userId) {
-            abort(response()->json([
-                'status' => 'error',
-                'message' => '未登入，無法操作。',
-            ], 401));
-        }
-
-        return $userId;
-    }
-
-    /**
      * 新增日記
      */
-    public function store(TarotDiaryRequest $request)
+    public function store(TarotDiaryRequest $request): \Illuminate\Http\JsonResponse
     {
-        $userId = $this->getUserIdOrAbort();
+        $userId = Auth::id();
 
         $this->service->createDiary($userId, $request->validated());
 
@@ -51,9 +36,9 @@ class TarotDiaryController extends Controller
     /**
      * 取得指定日記
      */
-    public function show($id, Request $request)
+    public function show($id, Request $request): \Illuminate\Http\JsonResponse
     {
-        $userId = $this->getUserIdOrAbort();
+        $userId = Auth::id();
 
         // 1. 取得指定日記
         $diary = $this->service->getDiary($userId, $id);
@@ -93,18 +78,14 @@ class TarotDiaryController extends Controller
     /**
      * 更新日記日期
      */
-    public function update(Request $request, $id)
+    public function update(UpdateTarotDiaryRequest $request, $id): \Illuminate\Http\JsonResponse
     {
-        $userId = $this->getUserIdOrAbort();
+        $userId = Auth::id();
 
-        $validated = $request->validate([
-            'user_entry_text' => 'required|string|max:200',
-        ]);
-
-        $diary = $this->service->updateDiaryDate($userId, $id, $validated['user_entry_text']);
+        $diary = $this->service->updateDiaryDate($userId, $id, $request->validated());
 
         $data = [
-            'update_at' => $diary->updated_at->toDateString(),
+            'updated_at' => $diary->updated_at->toDateString(),
             'user_entry_text' => $diary->user_entry_text,
         ];
 
@@ -114,9 +95,9 @@ class TarotDiaryController extends Controller
     /**
      * 月曆模式取得日記（前後一個月）
      */
-    public function getMonthDiaries(Request $request)
+    public function getMonthDiaries(Request $request): \Illuminate\Http\JsonResponse
     {
-        $userId = $this->getUserIdOrAbort();
+        $userId = Auth::id();
 
         $selectedDate = $request->query('date');
 

--- a/app/Http/Controllers/TarotDiaryController.php
+++ b/app/Http/Controllers/TarotDiaryController.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\TarotDiaryRequest;
+use App\Services\TarotDiaryService;
+use App\Traits\ApiResponse;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TarotDiaryController extends Controller
+{
+    use ApiResponse;
+
+    protected $service;
+
+    public function __construct(TarotDiaryService $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * 取得登入使用者 ID，如未登入則回傳錯誤
+     */
+    private function getUserIdOrAbort()
+    {
+        $userId = Auth::id();
+        if (! $userId) {
+            abort(response()->json([
+                'status' => 'error',
+                'message' => '未登入，無法操作。',
+            ], 401));
+        }
+
+        return $userId;
+    }
+
+    /**
+     * 新增日記
+     */
+    public function store(TarotDiaryRequest $request)
+    {
+        $userId = $this->getUserIdOrAbort();
+
+        $this->service->createDiary($userId, $request->validated());
+
+        return $this->success('日記創建成功');
+    }
+
+    /**
+     * 取得指定日記
+     */
+    public function show($id, Request $request)
+    {
+        $userId = $this->getUserIdOrAbort();
+
+        // 1. 取得指定日記
+        $diary = $this->service->getDiary($userId, $id);
+
+        // 2. 取得該日記所在範圍的月曆資料（前後三個月）
+        $selectedDate = $request->query('date', $diary->created_at->toDateString());
+
+        $diaries = $this->service->getMonthDiary($userId, $selectedDate);
+
+        // 3. 格式化回傳的資料
+        $data = [
+            'created_at' => Carbon::parse($diary->created_at)->toDateString(),
+            'user_entry_text' => $diary->user_entry_text,
+            'tarot_card' => [
+                'image' => $diary->tarot_specification->tarot->image_path,
+                'name' => $diary->tarot_specification->tarot->name,
+                'is_upright' => $diary->tarot_specification->is_upright,
+                'blessing_message' => $diary->tarot_specification->is_upright
+                    ? $diary->tarot_specification->message1
+                    : $diary->tarot_specification->message2,
+            ],
+            // 4. 這是月曆範圍內的其他日記
+            'month_diaries' => $diaries->map(function ($diary) {
+                return [
+                    'id' => $diary->id,
+                    'created_at' => $diary->created_at->toDateString(),
+                    'tarot_name' => $diary->tarot_specification->tarot->name,
+                    'is_upright' => $diary->tarot_specification->is_upright,
+                    'image' => $diary->tarot_specification->tarot->image_path,
+                ];
+            })->toArray(),
+        ];
+
+        return $this->responseWithData('日記取得成功', $data);
+    }
+
+    /**
+     * 更新日記日期
+     */
+    public function update(Request $request, $id)
+    {
+        $userId = $this->getUserIdOrAbort();
+
+        $validated = $request->validate([
+            'user_entry_text' => 'required|string|max:200',
+        ]);
+
+        $diary = $this->service->updateDiaryDate($userId, $id, $validated['user_entry_text']);
+
+        $data = [
+            'update_at' => $diary->updated_at->toDateString(),
+            'user_entry_text' => $diary->user_entry_text,
+        ];
+
+        return $this->responseWithData('日記更新成功', $data);
+    }
+
+    /**
+     * 月曆模式取得日記（前後一個月）
+     */
+    public function getMonthDiaries(Request $request)
+    {
+        $userId = $this->getUserIdOrAbort();
+
+        $selectedDate = $request->query('date');
+
+        $diaries = $this->service->getMonthDiary($userId, $selectedDate);
+
+        $data = $diaries->map(function ($diary) {
+            return [
+                'id' => $diary->id,
+                'created_at' => $diary->created_at->toDateString(),
+                'tarot_name' => $diary->tarotSpecification->tarot->name,
+                'is_upright' => $diary->tarotSpecification->is_upright,
+                'image' => $diary->tarotSpecification->tarot->image_path,
+            ];
+        })->toArray();
+
+        return $this->responseWithData('日記清單取得成功', $data);
+    }
+}

--- a/app/Http/Controllers/TarotDiaryController.php
+++ b/app/Http/Controllers/TarotDiaryController.php
@@ -28,7 +28,10 @@ class TarotDiaryController extends Controller
     {
         $userId = Auth::id();
 
-        $this->service->createDiary($userId, $request->validated());
+        // 驗證的資料
+        $validatedData = $request->validated();
+
+        $this->service->createDiary($userId, $validatedData);
 
         return $this->success('日記創建成功');
     }

--- a/app/Http/Requests/TarotDiaryRequest.php
+++ b/app/Http/Requests/TarotDiaryRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TarotDiaryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tarot_id' => ['required', 'integer'],
+            'user_entry_text' => ['required', 'string', 'max:200'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'user_entry_text.required' => '請輸入您的日記內容',
+            'user_entry_text.max' => '日記內容最多200字',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateTarotDiaryRequest.php
+++ b/app/Http/Requests/UpdateTarotDiaryRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTarotDiaryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'user_entry_text' => ['required', 'string', 'max:200'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'user_entry_text.required' => '請輸入您的日記內容',
+            'user_entry_text.max' => '日記內容最多200字',
+        ];
+    }
+}

--- a/app/Models/Diary.php
+++ b/app/Models/Diary.php
@@ -21,7 +21,11 @@ class Diary extends Model
         return $this->belongsTo(User::class);
     }
 
-    // 定義與 Tarot 的關聯（多對一)
+    /**
+     * 關聯到 TarotSpecification 模型
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function tarot_specification()
     {
         return $this->belongsTo(TarotSpecification::class);

--- a/app/Services/TarotDiaryService.php
+++ b/app/Services/TarotDiaryService.php
@@ -10,13 +10,12 @@ class TarotDiaryService
     /**
      * 建立新日記
      */
-    public function createDiary($userId, $data)
+    public function createDiary($userId, $data): Diary
     {
         return Diary::create([
             'user_id' => $userId,
-            'tarot_specification_id' => $data['tarot_id'] = 1,
+            'tarot_specification_id' => $data['tarot_id'],
             'user_entry_text' => $data['user_entry_text'],
-            'created_at' => $data['created_at'] ?? now(),
         ]);
     }
 
@@ -25,29 +24,25 @@ class TarotDiaryService
      */
     public function getDiary(int $userId, int $diaryId): Diary
     {
-        return Diary::with(['tarot_specification.tarot'])
-            ->where('user_id', $userId)
-            ->findOrFail($diaryId);
+        return Diary::with(['tarot_specification.tarot'])->where('user_id', $userId)->findOrFail($diaryId);
     }
 
     /**
-     * 更新日記的日期
+     * 更新日記
      */
-    public function updateDiaryDate(int $userId, int $diaryId, string $content): Diary
+    public function updateDiaryDate(int $userId, int $diaryId, array $data): Diary
     {
         $diary = Diary::where('user_id', $userId)->findOrFail($diaryId);
 
-        $diary->user_entry_text = $content;
-        $diary->updated_at = now();
-        $diary->save();
+        $diary->update(['user_entry_text' => $data['user_entry_text'] ?? $diary->user_entry_text]);
 
-        return $diary;
+        return $diary->fresh();
     }
 
     /**
      * 取得月曆範圍日記(前後各一個月份)
      */
-    public function getMonthDiary($user_id, $baseDate = null)
+    public function getMonthDiary($user_id, $baseDate = null): \Illuminate\Database\Eloquent\Collection
     {
         // 1. 設定基準日期（如果未提供，則使用當前日期）如果提供 $baseDate，解析它，否則使用當前時間
         $baseDate = $baseDate ? Carbon::parse($baseDate) : Carbon::now();

--- a/app/Services/TarotDiaryService.php
+++ b/app/Services/TarotDiaryService.php
@@ -42,7 +42,7 @@ class TarotDiaryService
     /**
      * 取得月曆範圍日記(前後各一個月份)
      */
-    public function getMonthDiary($user_id, $baseDate = null): \Illuminate\Database\Eloquent\Collection
+    public function getMonthDiary($user_id, $baseDate): \Illuminate\Database\Eloquent\Collection
     {
         // 1. 設定基準日期（如果未提供，則使用當前日期）如果提供 $baseDate，解析它，否則使用當前時間
         $baseDate = $baseDate ? Carbon::parse($baseDate) : Carbon::now();

--- a/app/Services/TarotDiaryService.php
+++ b/app/Services/TarotDiaryService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Diary;
+use Carbon\Carbon;
+
+class TarotDiaryService
+{
+    /**
+     * 建立新日記
+     */
+    public function createDiary($userId, $data)
+    {
+        return Diary::create([
+            'user_id' => $userId,
+            'tarot_specification_id' => $data['tarot_id'] = 1,
+            'user_entry_text' => $data['user_entry_text'],
+            'created_at' => $data['created_at'] ?? now(),
+        ]);
+    }
+
+    /**
+     * 取得單一日記資料（含塔羅牌資訊）
+     */
+    public function getDiary(int $userId, int $diaryId): Diary
+    {
+        return Diary::with(['tarot_specification.tarot'])
+            ->where('user_id', $userId)
+            ->findOrFail($diaryId);
+    }
+
+    /**
+     * 更新日記的日期
+     */
+    public function updateDiaryDate(int $userId, int $diaryId, string $content): Diary
+    {
+        $diary = Diary::where('user_id', $userId)->findOrFail($diaryId);
+
+        $diary->user_entry_text = $content;
+        $diary->updated_at = now();
+        $diary->save();
+
+        return $diary;
+    }
+
+    /**
+     * 取得月曆範圍日記(前後各一個月份)
+     */
+    public function getMonthDiary($user_id, $baseDate = null)
+    {
+        // 1. 設定基準日期（如果未提供，則使用當前日期）如果提供 $baseDate，解析它，否則使用當前時間
+        $baseDate = $baseDate ? Carbon::parse($baseDate) : Carbon::now();
+
+        // 2. 調整到當月第一天（00:00:00）
+        $baseDate->startOfMonth();
+
+        // 3. 計算查詢範圍：
+        //    - 開始日期 = 前一個月的第一天（00:00:00）
+        //    - 結束日期 = 後一個月的最後一天（23:59:59）
+        $startDate = $baseDate->copy()->subMonth(); // 前一個月
+        $endDate = $baseDate->copy()->addMonth()->endOfMonth(); // 後一個月的最後時刻
+
+        // 4. 查詢該用戶的日記（確保只查詢該用戶的資料）
+        return Diary::with(['tarot_specification.tarot'])
+            ->where('user_id', $user_id) // 確保只查詢該用戶的日記
+            ->whereBetween('created_at', [$startDate, $endDate])
+            ->orderBy('created_at', 'desc')
+            ->get();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\TarotDiaryController;
 use App\Http\Controllers\TarotDrawController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -18,6 +19,9 @@ Route::prefix('auth')->group(function (): void {
     Route::middleware('auth:api')->group(function (): void {
         Route::post('/logout', [AuthController::class, 'logout']);
         Route::post('/refresh', [AuthController::class, 'refresh']);
+        Route::post('/diaries', [TarotDiaryController::class, 'store']);
+        Route::get('/diaries/{id}', [TarotDiaryController::class, 'show']);
+        Route::put('/diaries/{id}', [TarotDiaryController::class, 'update']);
     });
 });
 


### PR DESCRIPTION
## 本次修改內容

**【API routes】**
  - 新增 POST /diaries 用於建立日記
  - 新增 GET /diaries/{id} 用於取得單一日記
  - 新增 PUT /diaries/{id} 用於更新日記

**【Controller】TarotDiaryController**
  - 實作日記 CRUD 操作
  - 新增月曆範圍資料查詢功能
  - 處理使用者驗證與資料格式化

**【Request】TarotDiaryRequest**
  - 新增 TarotDiaryRequest 驗證規則

**【Service】TarotDiaryService**
  - 封裝日記核心業務邏輯
  - 實作日期範圍查詢功能
  - 優化資料庫查詢 (預載入關聯)

**【Models】Diary**
  - 新增 Diary 模型關聯註解