### PR TITLE
Fix diary relation and add missing service import

### DIFF
--- a/app/Http/Controllers/TarotDiaryController.php
+++ b/app/Http/Controllers/TarotDiaryController.php
@@ -110,9 +110,9 @@ class TarotDiaryController extends Controller
             return [
                 'id' => $diary->id,
                 'created_at' => $diary->created_at->toDateString(),
-                'tarot_name' => $diary->tarotSpecification->tarot->name,
-                'is_upright' => $diary->tarotSpecification->is_upright,
-                'image' => $diary->tarotSpecification->tarot->image_path,
+                'tarot_name' => $diary->tarot_specification->tarot->name,
+                'is_upright' => $diary->tarot_specification->is_upright,
+                'image' => $diary->tarot_specification->tarot->image_path,
             ];
         })->toArray();
 

--- a/app/Services/EmailVerifyService.php
+++ b/app/Services/EmailVerifyService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\User;
+use App\Services\AuthService;
 
 class EmailVerifyService
 {


### PR DESCRIPTION
## Summary
- ensure month diary retrieval uses correct relation name
- import `AuthService` to Email verification service

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843108f56708323815dae1d084ccd83